### PR TITLE
Disable proxy

### DIFF
--- a/inc/psm.inc
+++ b/inc/psm.inc
@@ -39,7 +39,7 @@ function play_store_proxy_request($request) {
         $timeout = 30 + (30 * $i);
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_PROXY, PROXY);
+        // curl_setopt($ch, CURLOPT_PROXY, PROXY);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);

--- a/scripts/auto_requests.php
+++ b/scripts/auto_requests.php
@@ -135,7 +135,7 @@ foreach($ids as $id => $territory_ids) {
         echo(($response->available ? '✅' : '❌') . "\n");
         // we don't need to sleep with Tor as a proxy, it slows
         // things down enough to not get rate limited
-        // sleep(1);
+        sleep(1);
     }
     $duration = time() - $start;
     print "Duration: $duration\n";


### PR DESCRIPTION
Disable the proxy for now, and put the sleep() back in to auto_requests without the proxy slowing things down